### PR TITLE
Contributing: no changelog, lightweight review

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,8 @@ We gratefully accept contributions from the community.
 
 As with any open source project, contributions will be reviewed by the project team and community and may need some modifications to be accepted.
 
+The documentation in this repository only undergoes a light review. Incomplete documentation is better than none, and we encourage gradual improvements.
+
 Making a Contribution
 ---------------------
 
@@ -14,4 +16,4 @@ All contributions are made under the [Apache License 2.0](LICENSE).
 
 1. Fork the [Mbed TLS documentation repository on GitHub](https://github.com/ARMmbed/mbedtls-docs) to start making your changes.
 1. Ensure that each commit has at least one `Signed-off-by:` line from the committer. If anyone else contributes to the commit, they should also add their own `Signed-off-by:` line. By adding this line, contributor(s) certify that the contribution is made under the terms of the [Developer Certificate of Origin](dco.txt).
-1. Send a pull request (PR) and work with us until it gets merged and published. Contributions may need some modifications, so a few rounds of review and fixing may be necessary.
+1. Send a pull request (PR) and work with us until it gets merged and published.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ We gratefully accept contributions from the community.
 
 As with any open source project, contributions will be reviewed by the project team and community and may need some modifications to be accepted.
 
-The documentation in this repository only undergoes a light review. Incomplete documentation is better than none, and we encourage gradual improvements.
+The documentation in this repository only undergoes a light review. Please contribute any documentation that you think could be useful, even if it's incomplete. We encourage quick, iterative improvements.
 
 Making a Contribution
 ---------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,4 +14,4 @@ All contributions are made under the [Apache License 2.0](LICENSE).
 
 1. Fork the [Mbed TLS documentation repository on GitHub](https://github.com/ARMmbed/mbedtls-docs) to start making your changes.
 1. Ensure that each commit has at least one `Signed-off-by:` line from the committer. If anyone else contributes to the commit, they should also add their own `Signed-off-by:` line. By adding this line, contributor(s) certify that the contribution is made under the terms of the [Developer Certificate of Origin](dco.txt).
-1. Send a pull request (PR) and work with us until it gets merged and published. Contributions may need some modifications, so a few rounds of review and fixing may be necessary. We will include your name in the ChangeLog :)
+1. Send a pull request (PR) and work with us until it gets merged and published. Contributions may need some modifications, so a few rounds of review and fixing may be necessary.


### PR DESCRIPTION
Remove a copypasted mention of a changelog file: there is no changelog here.

Reduce the expectations on review.

