### PR TITLE
Zsh completion functions

### DIFF
--- a/tools/zsh/_all.sh
+++ b/tools/zsh/_all.sh
@@ -1,4 +1,4 @@
-#compdef all.sh
+#compdef all.sh tests_all
 ## Completion for tests/scripts/all.sh in Mbed TLS.
 
 _all_sh () {

--- a/tools/zsh/_all.sh
+++ b/tools/zsh/_all.sh
@@ -1,0 +1,37 @@
+#compdef all.sh
+## Completion for tests/scripts/all.sh in Mbed TLS.
+
+_all_sh () {
+  local line opt spec specs
+  specs=()
+  for line in "${(@M)${(@f)$(_call_program help $words[1] --help)}:# #-*}"; do
+    line=${line## ##}
+    opt=(${(s:|:)${line%%[= ]*}})
+    spec=
+    line=${line#"${line%%[= ]*}"}
+    if [[ $line == \=* ]]; then
+      spec=":${${line#\=}%% *}:"
+      if [[ $spec == ":<"*">:" ]]; then
+        spec=":${${spec#??}%??}:"
+      fi
+      case $spec in
+        *_dir_path:) spec="${spec}_dirs";;
+        *_path:) spec="${spec}_files -g \"*(.*)\"";;
+      esac
+    elif [[ $opt[1] == '-s' || $opt[1] == '--seed' ]]; then
+      spec=":seed:"
+    fi
+    line=${line##[^ ]# ##}
+    spec="[$line]${spec}"
+    specs+=($^opt$spec)
+  done
+  _arguments : $specs
+}
+
+_all_sh "%@"
+
+# Local Variables:
+# mode: sh
+# sh-shell: zsh
+# End:
+

--- a/tools/zsh/_all.sh
+++ b/tools/zsh/_all.sh
@@ -2,10 +2,11 @@
 ## Completion for tests/scripts/all.sh in Mbed TLS.
 
 _all_sh () {
-  local line opt spec specs
+  local components line opt spec specs
+  components=()
   specs=()
   for line in "${(@M)${(@f)$(_call_program help $words[1] --help)}:# #-*}"; do
-    line=${line## ##}
+    line=${line##[ ]##}
     opt=(${(s:|:)${line%%[= ]*}})
     spec=
     line=${line#"${line%%[= ]*}"}
@@ -21,10 +22,16 @@ _all_sh () {
     elif [[ $opt[1] == '-s' || $opt[1] == '--seed' ]]; then
       spec=":seed:"
     fi
-    line=${line##[^ ]# ##}
+    line=${line##[^ ]#[ ]##}
     spec="[$line]${spec}"
     specs+=($^opt$spec)
+    if ((${#${(M)opt:#--list-components}})); then
+      components=("${(@M)${(@f)$(_call_program list-components $words[1] --list-components)}}")
+    fi
   done
+  if (($#components)); then
+    specs+=("*:component:($components)")
+  fi
   _arguments : $specs
 }
 

--- a/tools/zsh/_config.pl
+++ b/tools/zsh/_config.pl
@@ -1,5 +1,5 @@
-#compdef config.pl
-## Completion for scripts/config.pl in Mbed TLS.
+#compdef config.pl config.py
+## Completion for scripts/config.pl and scripts/config.pl in Mbed TLS.
 
 _config_pl_symbols () {
   local -a identifiers

--- a/tools/zsh/_config.pl
+++ b/tools/zsh/_config.pl
@@ -1,0 +1,46 @@
+#compdef config.pl
+## Completion for scripts/config.pl in Mbed TLS.
+
+_config_pl_symbols () {
+  local -a identifiers
+  #identifiers=("${(@f)$(_call_program get_symbols sed -n 's!^/*\**#define \(MBEDTLS_[0-9A-Z_a-z][0-9A-Z_a-z]*\).*!\1!p' $config_h)}")
+  identifiers=("${(@f)$(sed -n 's!^/*\**#define \(MBEDTLS_[0-9A-Z_a-z][0-9A-Z_a-z]*\).*!\1!p' $config_h)}")
+  _describe -t symbols 'config.h symbols' identifiers
+}
+
+_config_pl () {
+  local context state state_descr line
+  typeset -A opt_args
+  local ret=0 config_h=$words[1]:h/../include/mbedtls/config.h
+  local -a commands_with_descriptions
+  commands_with_descriptions=(
+    'baremetal:All features for bare metal platforms'
+    'get:Get symbol value'
+    'full:All features'
+    'realfull:Uncomment all #define'\'''
+    'set:Actvate symbol'
+    'unset:Deactivate symbol'
+  )
+  _arguments \
+    {'-f','--file'}'[file to edit]:file to edit:_files -g "*.h"' \
+    {'-o','--force'}'[define symbol even if not present]' \
+    '1:config.pl command:->command' \
+    '*::config.pl commands:->param'
+  case $state in
+    (command)
+      _describe -t commands 'config.pl command' commands_with_descriptions;;
+    (param)
+      case $words[1]:$CURRENT in
+        ((get|set|unset):2) _call_function ret _config_pl_symbols;;
+      esac;;
+  esac
+  return $ret
+}
+
+_config_pl "%@"
+
+# Local Variables:
+# mode: sh
+# sh-shell: zsh
+# End:
+

--- a/tools/zsh/_config.pl
+++ b/tools/zsh/_config.pl
@@ -3,8 +3,7 @@
 
 _config_pl_symbols () {
   local -a identifiers
-  #identifiers=("${(@f)$(_call_program get_symbols sed -n 's!^/*\**#define \(MBEDTLS_[0-9A-Z_a-z][0-9A-Z_a-z]*\).*!\1!p' $config_h)}")
-  identifiers=("${(@f)$(sed -n 's!^/*\**#define \(MBEDTLS_[0-9A-Z_a-z][0-9A-Z_a-z]*\).*!\1!p' $config_h)}")
+  identifiers=("${(@f)$(_call_program _config_pl_symbols sed -n \''s!^/*\**#define \(MBEDTLS_[0-9A-Z_a-z][0-9A-Z_a-z]*\).*!\1!p'\' \$config_h)}")
   _describe -t symbols 'config.h symbols' identifiers
 }
 

--- a/tools/zsh/_mbedtls-prepare-build
+++ b/tools/zsh/_mbedtls-prepare-build
@@ -60,6 +60,13 @@ _mbedtls_prepare_build () {
       _call_function ret _command_names -e;;
     (--config-file)
       _call_function ret _files -g "*.h";;
+    (--config-mode)
+      local -a config_modes
+      config_modes=(
+        'copy:Copy config.h'
+        'include:#include ${SOURCE_DIR}/config.h'
+      )
+      _call_function ret _describe -t config_mode 'Handling of config.h' config_modes;;
     (--config-name)
       local -a config_names
       config_names=(

--- a/tools/zsh/_mbedtls-prepare-build
+++ b/tools/zsh/_mbedtls-prepare-build
@@ -1,0 +1,76 @@
+#compdef mbedtls-prepare-build
+
+_mbedtls_prepare_build_symbols () {
+  local -a identifiers
+  identifiers=("${(@f)$(sed -n 's!^/*\**#define \(MBEDTLS_[0-9A-Z_a-z][0-9A-Z_a-z]*\).*!\1!p' $source_dir/include/mbedtls/config.h 2>/dev/null)}")
+  if ((!$#identifiers)); then return 1; fi
+  _values -s , 'config.h symbols' $identifiers
+}
+
+_mbedtls_prepare_build () {
+  local context state state_descr line
+  typeset -A opt_args
+  local ret=0
+  local prefix spec specs
+  local source_dir=. args
+  specs=()
+  args=($words[2,-1])
+
+  while (($#args)); do
+    case $args[1] in
+      (-s|--source) if (($#args >= 2)); then source_dir=$args[2]; fi;;
+      (--*=*) :;;
+      -*) if (($#args >= 2)); then shift args; fi;;
+    esac
+    shift args
+  done
+
+  for line in "${(@f)${$(export COLUMNS=9999;
+                         _call_program help $words[1] --help)//$'\n    '/  }}"; do
+    # 1=opt1 3=?arg1 5=?opt2 7=descr
+    if [[ $line =~ "  (-[^ ]+)( ([^- ][^ ]*))?(, (-[^ ]+)( [^- ][^ ]*)?)*  +(.*)" ]]; then
+      spec="[${match[7]//\]/\\\]}]"
+      if [[ -n $match[3] ]]; then
+        spec="=$spec:$match[3]:->${match[1]}"
+      fi
+      case $match[1] in
+        (--config-set|--config-unset|--var) prefix='*';;
+        (*) prefix=;;
+      esac
+      if [[ -n $match[5] ]]; then
+        specs+=($prefix{$match[1],$match[5]}$spec)
+      else
+        specs+=($prefix$match[1]$spec)
+      fi
+    fi
+  done
+  line=
+  _arguments $specs
+
+  case $state in
+    (--ar|--cc|--cp|--perl|--python|--rm|--valgrind)
+      _call_function ret _command_names -e;;
+    (--config-file)
+      _call_function ret _files -g "*.h";;
+    (--config-name)
+      local -a config_names
+      config_names=(
+        'baremetal:All features for bare metal platforms'
+        'full:All features'
+        'realfull:Uncomment all #define'\'''
+      )
+      _call_function ret _describe -t config_name 'Preset configuration name' config_names;;
+    (--config-set|--config-unset)
+      _call_function ret _mbedtls_prepare_build_symbols;;
+    (--dir|--source)
+      _call_function ret _dirs;;
+  esac
+  return $ret
+}
+
+_mbedtls_prepare_build "$@"
+
+# Local Variables:
+# mode: sh
+# sh-shell: zsh
+# End:

--- a/tools/zsh/_mbedtls-prepare-build
+++ b/tools/zsh/_mbedtls-prepare-build
@@ -2,7 +2,7 @@
 
 _mbedtls_prepare_build_symbols () {
   local -a identifiers
-  identifiers=("${(@f)$(sed -n 's!^/*\**#define \(MBEDTLS_[0-9A-Z_a-z][0-9A-Z_a-z]*\).*!\1!p' $source_dir/include/mbedtls/config.h 2>/dev/null)}")
+  identifiers=("${(@f)$(_call_program _config_pl_symbols sed -n \''s!^/*\**#define \(MBEDTLS_[0-9A-Z_a-z][0-9A-Z_a-z]*\).*!\1!p'\' \$source_dir/include/mbedtls/config.h)}")
   if ((!$#identifiers)); then return 1; fi
   _values -s , 'config.h symbols' $identifiers
 }

--- a/tools/zsh/_mbedtls-prepare-build
+++ b/tools/zsh/_mbedtls-prepare-build
@@ -32,16 +32,28 @@ _mbedtls_prepare_build () {
     # 1=opt1 3=?arg1 5=?opt2 7=descr
     if [[ $state == 'options' &&
           $line =~ '  (-[^ ]+)( ([^- ][^ ]*))?(, (-[^ ]+)( [^- ][^ ]*)?)*  +(.*)' ]]; then
-      spec="[${match[7]//\]/\\\]}]"
+      spec="[${${match[7]//\]/\\\]}//:/\\:}]"
       if [[ -n $match[3] ]]; then
         spec="=$spec:$match[3]:->${match[1]}"
       fi
       case $match[1] in
         (--config-set|--config-unset|--var) prefix='*';;
-        (*) prefix=;;
+        (*) prefix="($match[1] $match[5])";;
       esac
       if [[ -n $match[5] ]]; then
-        specs+=($prefix{$match[1],$match[5]}$spec)
+        if [[ -n $spec ]]; then
+          if [[ $match[1] == --* ]]; then
+            match[1]="$match[1]="
+          else
+            match[1]="$match[1]+"
+          fi
+          if [[ $match[5] == --* ]]; then
+            match[5]="$match[5]="
+          else
+            match[5]="$match[5]+"
+          fi
+        fi
+        specs+=($prefix{$match[1],$match[5]}${spec#\=})
       else
         specs+=($prefix$match[1]$spec)
       fi
@@ -53,6 +65,7 @@ _mbedtls_prepare_build () {
     fi
   done
   line=
+  s=($specs)
   _arguments $specs
 
   case $state in

--- a/tools/zsh/_mbedtls-prepare-build
+++ b/tools/zsh/_mbedtls-prepare-build
@@ -11,10 +11,11 @@ _mbedtls_prepare_build () {
   local context state state_descr line
   typeset -A opt_args
   local ret=0
-  local prefix spec specs
-  local source_dir=. args
-  specs=()
-  args=($words[2,-1])
+  local prefix spec
+  local -a specs; specs=()
+  local source_dir=.
+  local -a args; args=($words[2,-1])
+  local -a presets; presets=()
 
   while (($#args)); do
     case $args[1] in
@@ -25,10 +26,12 @@ _mbedtls_prepare_build () {
     shift args
   done
 
+  state='options'
   for line in "${(@f)${$(export COLUMNS=9999;
                          _call_program help $words[1] --help)//$'\n    '/  }}"; do
     # 1=opt1 3=?arg1 5=?opt2 7=descr
-    if [[ $line =~ "  (-[^ ]+)( ([^- ][^ ]*))?(, (-[^ ]+)( [^- ][^ ]*)?)*  +(.*)" ]]; then
+    if [[ $state == 'options' &&
+          $line =~ '  (-[^ ]+)( ([^- ][^ ]*))?(, (-[^ ]+)( [^- ][^ ]*)?)*  +(.*)' ]]; then
       spec="[${match[7]//\]/\\\]}]"
       if [[ -n $match[3] ]]; then
         spec="=$spec:$match[3]:->${match[1]}"
@@ -42,6 +45,11 @@ _mbedtls_prepare_build () {
       else
         specs+=($prefix$match[1]$spec)
       fi
+    elif [[ $state == 'presets' &&
+            $line =~ '([-0-9A-Z_a-z]+): *(.*)' ]]; then
+      presets+=($match[1]:$match[2])
+    elif [[ $line == 'Presets:' ]]; then
+      state='presets'
     fi
   done
   line=
@@ -57,13 +65,15 @@ _mbedtls_prepare_build () {
       config_names=(
         'baremetal:All features for bare metal platforms'
         'full:All features'
-        'realfull:Uncomment all #define'\'''
+        'realfull:Uncomment all #define'\''s'
       )
       _call_function ret _describe -t config_name 'Preset configuration name' config_names;;
     (--config-set|--config-unset)
       _call_function ret _mbedtls_prepare_build_symbols;;
     (--dir|--source)
       _call_function ret _dirs;;
+    (--preset)
+      _call_function ret _describe -t preset 'Preset build name' presets;;
   esac
   return $ret
 }

--- a/tools/zsh/_mbedtls-prepare-build
+++ b/tools/zsh/_mbedtls-prepare-build
@@ -71,7 +71,7 @@ _mbedtls_prepare_build () {
     (--config-set|--config-unset)
       _call_function ret _mbedtls_prepare_build_symbols;;
     (--dir|--source)
-      _call_function ret _dirs;;
+      _call_function ret _files -/;;
     (--preset)
       _call_function ret _describe -t preset 'Preset build name' presets;;
   esac

--- a/tools/zsh/_ssl-opt.sh
+++ b/tools/zsh/_ssl-opt.sh
@@ -1,0 +1,46 @@
+#compdef ssl-opt.sh compat.sh
+## Completion for tests/ssl-opt.sh and tests/compat.sh in Mbed TLS.
+
+_compat_sh_set_values () {
+  spec="$spec:$1: _values -s ' ' '$1' ${${line%'*}##*'}"
+}
+
+_ssl_opt_sh () {
+  local line opt spec specs
+  specs=()
+  for line in "${(@M)${(@)${(@f)$(_call_program help $words[1] --help)}//$'\t'##/ }:# #-*}"; do
+    line=${line## ##}
+    opt=(${(s:|:)${line%%[= ]*}})
+    spec=
+    line=${line#"${line%%[= ]*}"}
+    line=${line##[^ ]# ##}
+    spec="[$line]${spec}"
+    case $words[1]:t:r in
+      compat)
+        case $opt[1] in
+          -V) _compat_sh_set_values 'Verification modes';;
+          -e) spec="${spec}:Exclude matching ciphersuites (BRE):";;
+          -f) spec="${spec}:Restrict to matching ciphersuites (BRE):";;
+          -m) _compat_sh_set_values 'Protocol versions';;
+          -p) _compat_sh_set_values 'Peers';;
+          -t) _compat_sh_set_values 'Key exchange types';;
+        esac;;
+      ssl-opt)
+        case $opt[1] in
+          -e|-f) spec="${spec}:BRE:";;
+          --port|--*-port) spec="${spec}:port number:";;
+          --seed) spec="${spec}:seed:";;
+        esac;;
+    esac
+    specs+=($^opt$spec)
+  done
+  _arguments : $specs
+}
+
+_ssl_opt_sh "%@"
+
+# Local Variables:
+# mode: sh
+# sh-shell: zsh
+# End:
+

--- a/tools/zsh/_test-ref-configs.pl
+++ b/tools/zsh/_test-ref-configs.pl
@@ -1,0 +1,14 @@
+#compdef test-ref-configs.pl
+## Completion for tests/test-ref-configs.pl in Mbed TLS.
+
+_test_ref_configs_pl () {
+  compadd $(sed -n '/%configs *=/,/;/ s/^ *'\''\([^'\'']*\)'\'' => {$/\1/p' $words[1])
+}
+
+_test_ref_configs_pl "%@"
+
+# Local Variables:
+# mode: sh
+# sh-shell: zsh
+# End:
+


### PR DESCRIPTION
Zsh completion functions for:

* `config.pl` and `config.py`
* `test-ref-configs.pl`
* `ssl-opt.sh`
* `all.sh`
* `mbedtls-prepare-build` (see https://github.com/ARMmbed/mbedtls-docs/pull/7)

Usage: add the `zsh` directory to your `fpath` then (re)run `compinit`.