### PR TITLE
Add Sphinx configuration.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
-Contributing
-============
+Contributing to This Documentation
+==================================
 
 We gratefully accept contributions from the community.
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/conf.py
+++ b/conf.py
@@ -1,0 +1,52 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Mbed TLS'
+copyright = '2021, The Mbed TLS Contributors'
+author = 'The Mbed TLS Contributors'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/conf.py
+++ b/conf.py
@@ -35,7 +35,8 @@ templates_path = ['_templates']
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store',
+                    'README.md', 'CONTRIBUTING.md', 'tools/README.md']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/conf.py
+++ b/conf.py
@@ -36,7 +36,7 @@ templates_path = ['_templates']
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store',
-                    'README.md', 'CONTRIBUTING.md', 'tools/README.md']
+                    'README.md', 'tools/README.md']
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/conf.py
+++ b/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'Mbed TLS'
-copyright = '2021, The Mbed TLS Contributors'
+copyright = 'The Mbed TLS Contributors'
 author = 'The Mbed TLS Contributors'
 
 

--- a/conf.py
+++ b/conf.py
@@ -27,8 +27,7 @@ author = 'The Mbed TLS Contributors'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-]
+extensions = ['myst_parser']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/index.rst
+++ b/index.rst
@@ -3,8 +3,17 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to Mbed TLS's documentation!
-====================================
+Mbed TLS documentation hub
+==========================
+
+This is the unified documentation for the Mbed TLS project.
+This documentation is currently incomplete and will be expanded over time.
+For more information, see the following:
+
+* `GitHub repository <https://github.com/ARMmbed/mbedtls>`_
+* `Documentation GitHub Repository <https://github.com/ARMmbed/mbedtls-docs>`_
+* `Mbed TLS page on trustedfirmware.org <https://www.trustedfirmware.org/projects/mbed-tls/>`_
+* `Legacy website <https://tls.mbed.org>`_
 
 .. toctree::
    :maxdepth: 2

--- a/index.rst
+++ b/index.rst
@@ -10,7 +10,10 @@ Welcome to Mbed TLS's documentation!
    :maxdepth: 2
    :caption: Contents:
 
-
+   reviews/review_guidelines.md
+   architecture/proposed/long-term-plans.md
+   security-advisories/security-advisories.md
+   maintainers.md
 
 Indices and tables
 ==================

--- a/index.rst
+++ b/index.rst
@@ -23,6 +23,7 @@ For more information, see the following:
    architecture/proposed/long-term-plans.md
    security-advisories/security-advisories.md
    maintainers.md
+   CONTRIBUTING.md
 
 Indices and tables
 ==================

--- a/index.rst
+++ b/index.rst
@@ -1,0 +1,20 @@
+.. Mbed TLS documentation master file, created by
+   sphinx-quickstart on Thu Jul 29 17:27:29 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Mbed TLS's documentation!
+====================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd


### PR DESCRIPTION
This adds the `conf.py` and `index.rst` files required by sphinx to build the documentation.

Signed-off-by: David Horstmann <david.horstmann@arm.com>