### PR TITLE
Zsh completion: support mbedtls_config.h as well as config.h

### DIFF
--- a/tools/zsh/_config.pl
+++ b/tools/zsh/_config.pl
@@ -10,7 +10,8 @@ _config_pl_symbols () {
 _config_pl () {
   local context state state_descr line
   typeset -A opt_args
-  local ret=0 config_h=$words[1]:h/../include/mbedtls/config.h
+  local ret=0 config_h
+  config_h=($words[1]:h/../include/mbedtls/(mbedtls_|)config.h(N[1]))
   local -a commands_with_descriptions
   commands_with_descriptions=(
     'baremetal:All features for bare metal platforms'

--- a/tools/zsh/_mbedtls-prepare-build
+++ b/tools/zsh/_mbedtls-prepare-build
@@ -7,8 +7,9 @@ _mbedtls_prepare_build_cross () {
 }
 
 _mbedtls_prepare_build_symbols () {
-  local -a identifiers
-  identifiers=("${(@f)$(_call_program _config_pl_symbols sed -n \''s!^/*\**#define \(MBEDTLS_[0-9A-Z_a-z][0-9A-Z_a-z]*\).*!\1!p'\' \$source_dir/include/mbedtls/config.h)}")
+  local -a identifiers config_h
+  config_h=($source_dir/include/mbedtls/(mbedtls_|)config.h(N[1]))
+  identifiers=("${(@f)$(_call_program _config_pl_symbols sed -n \''s!^/*\**#define \(MBEDTLS_[0-9A-Z_a-z][0-9A-Z_a-z]*\).*!\1!p'\' \$config_h)}")
   if ((!$#identifiers)); then return 1; fi
   _values -s , 'config.h symbols' $identifiers
 }


### PR DESCRIPTION
I forgot this in https://github.com/ARMmbed/mbedtls-docs/pull/17.